### PR TITLE
Realtime anonymous viewer access + security hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,7 @@ SUPABASE_SERVICE_KEY=
 
 REDIS_DOMAIN=
 REDIS_PREFIX=
-REDIS_USERNAME=
-REDIS_PASSWORD=
+
+# Cloudflare Turnstile site key; leave empty to disable CAPTCHA widgets.
+# The matching secret key is configured in the Supabase dashboard.
+VITE_TURNSTILE_SITE_KEY=

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@dnd-kit/react": "^0.5.0",
     "@fontsource-variable/inter": "^5.2.8",
     "@hookform/resolvers": "^5.4.0",
+    "@marsidev/react-turnstile": "1.5.3",
     "@posthog/react": "^1.10.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-aspect-ratio": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.79.0(react@19.2.7))
+      '@marsidev/react-turnstile':
+        specifier: 1.5.3
+        version: 1.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@posthog/react':
         specifier: ^1.10.1
         version: 1.10.1(@types/react@19.2.17)(posthog-js@1.386.6)(react@19.2.7)
@@ -669,6 +672,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@marsidev/react-turnstile@1.5.3':
+    resolution: {integrity: sha512-8Dij2jiNGNczq1U4EKpO4do2XepcTPxSMc2ZzvHndO+gcp68tvMULm27z2P99rGkdB89hc3452NZeu2Rti4g6A==}
+    peerDependencies:
+      react: ^17.0.2 || ^18.0.0 || ^19.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -5564,6 +5573,11 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@marsidev/react-turnstile@1.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:

--- a/src/components/auth/AuthCaptcha.tsx
+++ b/src/components/auth/AuthCaptcha.tsx
@@ -1,0 +1,59 @@
+import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile';
+import React from 'react';
+
+const siteKey: string | undefined = import.meta.env.VITE_TURNSTILE_SITE_KEY;
+
+export const isCaptchaEnabled = () => Boolean(siteKey);
+
+export type AuthCaptchaHandle = {
+  /** Turnstile tokens are single-use; reset after every Auth request. */
+  reset: () => void;
+};
+
+/**
+ * Shared Cloudflare Turnstile widget for Supabase Auth flows. Calls
+ * `onToken` with a fresh token on success and with `null` on expiry or
+ * error. Renders nothing when no site key is configured, so Auth calls
+ * fall back to tokenless requests (CAPTCHA disabled in Supabase).
+ */
+export const AuthCaptcha = React.forwardRef<
+  AuthCaptchaHandle,
+  {
+    onToken: (token: string | null) => void;
+    className?: string;
+  }
+>(({ onToken, className }, ref) => {
+  const turnstileRef = React.useRef<TurnstileInstance | null>(null);
+  const onTokenRef = React.useRef(onToken);
+
+  React.useEffect(() => {
+    onTokenRef.current = onToken;
+  }, [onToken]);
+
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      reset: () => {
+        onTokenRef.current(null);
+        turnstileRef.current?.reset();
+      },
+    }),
+    [],
+  );
+
+  if (!siteKey) return null;
+
+  return (
+    <Turnstile
+      ref={turnstileRef}
+      className={className}
+      siteKey={siteKey}
+      onSuccess={(token) => onTokenRef.current(token)}
+      onExpire={() => {
+        onTokenRef.current(null);
+        turnstileRef.current?.reset();
+      }}
+      onError={() => onTokenRef.current(null)}
+    />
+  );
+});

--- a/src/components/auth/ForgotPasswordDialog.tsx
+++ b/src/components/auth/ForgotPasswordDialog.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import { toast } from 'sonner';
+import {
+  AuthCaptcha,
+  type AuthCaptchaHandle,
+} from '@/components/auth/AuthCaptcha';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -25,6 +29,8 @@ export const ForgotPasswordDialog = ({
 }) => {
   const [isLoading, setIsLoading] = React.useState(false);
   const [requestAccepted, setRequestAccepted] = React.useState(false);
+  const [captchaToken, setCaptchaToken] = React.useState<string | null>(null);
+  const captchaRef = React.useRef<AuthCaptchaHandle | null>(null);
   const supabase = useSupabase();
 
   const form = useAppForm({
@@ -38,7 +44,9 @@ export const ForgotPasswordDialog = ({
           flow: 'recovery',
           next: '/',
         }),
+        captchaToken: captchaToken ?? undefined,
       });
+      captchaRef.current?.reset();
       setIsLoading(false);
 
       if (error) {
@@ -121,6 +129,11 @@ export const ForgotPasswordDialog = ({
                     <field.FieldInfo field={field} />
                   </field.Field>
                 )}
+              />
+              <AuthCaptcha
+                ref={captchaRef}
+                onToken={setCaptchaToken}
+                className="mt-3"
               />
               <DialogFooter className="mt-4">
                 <form.WaitButton loading={isLoading} type="submit">

--- a/src/components/auth/SignIn.tsx
+++ b/src/components/auth/SignIn.tsx
@@ -1,5 +1,9 @@
 import { useNavigate } from '@tanstack/react-router';
 import React from 'react';
+import {
+  AuthCaptcha,
+  type AuthCaptchaHandle,
+} from '@/components/auth/AuthCaptcha';
 import { ErrorDialog } from '@/components/auth/ErrorDialog';
 import { ForgotPasswordDialog } from '@/components/auth/ForgotPasswordDialog';
 import { SignInWithGoogle } from '@/components/auth/SignInWithGoogle';
@@ -49,6 +53,10 @@ export const SignIn = React.memo(
       null,
     );
     const [showErrorDialog, setShowErrorDialog] = React.useState(false);
+    const [captchaToken, setCaptchaToken] = React.useState<string | null>(
+      null,
+    );
+    const captchaRef = React.useRef<AuthCaptchaHandle | null>(null);
     const auth = useSupabaseAuth();
 
     React.useEffect(() => {
@@ -71,7 +79,11 @@ export const SignIn = React.memo(
       onSubmit: async ({ value: { email, password } }) => {
         setIsLoading(true);
         try {
-          await auth.login({ email, password });
+          await auth.login({
+            email,
+            password,
+            captchaToken: captchaToken ?? undefined,
+          });
           await navigate({ to: getSafeRedirectPath(redirect) });
         } catch (loginError) {
           setMessageBoxTitle('Sign in error');
@@ -82,6 +94,7 @@ export const SignIn = React.memo(
           );
           setShowErrorDialog(true);
         } finally {
+          captchaRef.current?.reset();
           setIsLoading(false);
         }
       },
@@ -154,6 +167,7 @@ export const SignIn = React.memo(
                       </field.Field>
                     )}
                   />
+                  <AuthCaptcha ref={captchaRef} onToken={setCaptchaToken} />
                 </CardContent>
                 <CardFooter className="flex-col gap-4">
                   <form.WaitButton loading={isLoading} className="w-full">

--- a/src/components/auth/SignUpDialog.tsx
+++ b/src/components/auth/SignUpDialog.tsx
@@ -1,6 +1,11 @@
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import React from 'react';
 import { toast } from 'sonner';
+import {
+  AuthCaptcha,
+  type AuthCaptchaHandle,
+  isCaptchaEnabled,
+} from '@/components/auth/AuthCaptcha';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -30,6 +35,8 @@ export const SignUpDialog = ({
   const [isResending, setIsResending] = React.useState(false);
   const [pendingEmail, setPendingEmail] = React.useState<string | null>(null);
   const [resendSeconds, setResendSeconds] = React.useState(0);
+  const [captchaToken, setCaptchaToken] = React.useState<string | null>(null);
+  const captchaRef = React.useRef<AuthCaptchaHandle | null>(null);
   const supabase = useSupabase();
   const router = useRouter();
   const navigate = useNavigate();
@@ -73,8 +80,10 @@ export const SignUpDialog = ({
         options: {
           data: trimmedName ? { name: trimmedName } : {},
           emailRedirectTo: getEmailRedirectTo(),
+          captchaToken: captchaToken ?? undefined,
         },
       });
+      captchaRef.current?.reset();
       setIsLoading(false);
 
       if (error) {
@@ -125,8 +134,12 @@ export const SignUpDialog = ({
     const { error } = await supabase.auth.resend({
       type: 'signup',
       email: pendingEmail,
-      options: { emailRedirectTo: getEmailRedirectTo() },
+      options: {
+        emailRedirectTo: getEmailRedirectTo(),
+        captchaToken: captchaToken ?? undefined,
+      },
     });
+    captchaRef.current?.reset();
     setIsResending(false);
 
     if (error) {
@@ -136,7 +149,7 @@ export const SignUpDialog = ({
 
     setResendSeconds(RESEND_COOLDOWN_SECONDS);
     toast.success('Verification email resent');
-  }, [getEmailRedirectTo, pendingEmail, resendSeconds, supabase]);
+  }, [captchaToken, getEmailRedirectTo, pendingEmail, resendSeconds, supabase]);
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -154,6 +167,7 @@ export const SignUpDialog = ({
               If the message does not arrive, check your spam folder or resend
               it below.
             </p>
+            <AuthCaptcha ref={captchaRef} onToken={setCaptchaToken} />
             <DialogFooter className="flex-col sm:flex-row">
               <Button
                 type="button"
@@ -164,7 +178,11 @@ export const SignUpDialog = ({
               </Button>
               <Button
                 type="button"
-                disabled={isResending || resendSeconds > 0}
+                disabled={
+                  isResending ||
+                  resendSeconds > 0 ||
+                  (isCaptchaEnabled() && !captchaToken)
+                }
                 onClick={handleResend}
               >
                 {isResending
@@ -255,6 +273,7 @@ export const SignUpDialog = ({
                     </field.Field>
                   )}
                 />
+                <AuthCaptcha ref={captchaRef} onToken={setCaptchaToken} />
               </div>
               <DialogFooter className="mt-4">
                 <form.WaitButton loading={isLoading} type="submit">

--- a/src/components/show/RealtimeViewerGate.tsx
+++ b/src/components/show/RealtimeViewerGate.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import {
+  AuthCaptcha,
+  type AuthCaptchaHandle,
+  isCaptchaEnabled,
+} from '@/components/auth/AuthCaptcha';
+import { useSupabase } from '@/hooks/useSupabase';
+import { authorizeRealtimeViewer } from '@/server/joincodes';
+
+type GateStatus = 'checking' | 'captcha' | 'authorizing' | 'ready' | 'error';
+
+/**
+ * Authorizes a viewer for a private game channel before mounting the game.
+ * Viewers without a session are silently signed in as Supabase anonymous
+ * users (with a Turnstile token when CAPTCHA is enabled); the server then
+ * records a read grant for this game before the realtime subscription opens.
+ */
+export const RealtimeViewerGate = ({
+  code,
+  children,
+}: {
+  code: string;
+  children: React.ReactNode;
+}) => {
+  const supabase = useSupabase();
+  const [status, setStatus] = React.useState<GateStatus>('checking');
+  const startedRef = React.useRef(false);
+  const captchaRef = React.useRef<AuthCaptchaHandle | null>(null);
+
+  const signInAndAuthorize = React.useCallback(
+    async (captchaToken?: string) => {
+      setStatus('authorizing');
+      try {
+        const { error } = await supabase.auth.signInAnonymously({
+          options: captchaToken ? { captchaToken } : undefined,
+        });
+        if (error) throw error;
+        await authorizeRealtimeViewer({ data: { code } });
+        setStatus('ready');
+      } catch {
+        captchaRef.current?.reset();
+        setStatus('error');
+      }
+    },
+    [code, supabase],
+  );
+
+  React.useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    (async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (session) {
+        try {
+          await authorizeRealtimeViewer({ data: { code } });
+          setStatus('ready');
+        } catch {
+          setStatus('error');
+        }
+        return;
+      }
+
+      if (isCaptchaEnabled()) {
+        setStatus('captcha');
+        return;
+      }
+
+      await signInAndAuthorize();
+    })();
+  }, [code, signInAndAuthorize, supabase]);
+
+  if (status === 'ready') return <>{children}</>;
+
+  if (status === 'error') {
+    return (
+      <div className="h-screen w-screen flex items-center justify-center p-4">
+        <p className="text-center text-lg">
+          This link is invalid or has expired. Ask the host for a new one.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen w-screen flex flex-col items-center justify-center gap-4 p-4">
+      {status === 'captcha' && (
+        <AuthCaptcha
+          ref={captchaRef}
+          onToken={(token) => {
+            if (token) void signInAndAuthorize(token);
+          }}
+        />
+      )}
+      <p className="text-muted-foreground">Connecting to the game…</p>
+    </div>
+  );
+};

--- a/src/hooks/useGameActionSubscription.tsx
+++ b/src/hooks/useGameActionSubscription.tsx
@@ -38,7 +38,9 @@ export const useGameActionSubscription = ({
     if (!channelId) return;
 
     const channel = supabase
-      .channel(channelId)
+      .channel(channelId, {
+        config: { private: true },
+      })
       .on('broadcast', { event: 'GameAction' }, (event) => {
         const { type, state } = sentEvent.parse(event.payload);
         onStateRef.current?.(state);

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -16,6 +16,9 @@ describe('auth helpers', () => {
     );
     expect(getSafeRedirectPath('https://attacker.example')).toBe('/');
     expect(getSafeRedirectPath('//attacker.example')).toBe('/');
+    expect(getSafeRedirectPath('/\\attacker.example')).toBe('/');
+    expect(getSafeRedirectPath('/\\/attacker.example')).toBe('/');
+    expect(getSafeRedirectPath('/\\@attacker.example')).toBe('/');
     expect(getSafeRedirectPath(undefined, '/login')).toBe('/login');
   });
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -14,7 +14,11 @@ export const getSafeRedirectPath = (
   redirect: string | null | undefined,
   fallback = '/',
 ) => {
-  if (!redirect?.startsWith('/') || redirect.startsWith('//')) {
+  if (
+    !redirect?.startsWith('/') ||
+    redirect.startsWith('//') ||
+    redirect.includes('\\')
+  ) {
     return fallback;
   }
 

--- a/src/routes/_auth.c.$gameInstanceId.tsx
+++ b/src/routes/_auth.c.$gameInstanceId.tsx
@@ -148,7 +148,9 @@ function ControlComponent() {
 
   const handleSendSound = React.useCallback(
     async (sound: GameSound) => {
-      const channel = supabaseClient.channel(gameInstanceId);
+      const channel = supabaseClient.channel(gameInstanceId, {
+        config: { private: true },
+      });
       try {
         await channel.httpSend('sound', { sound });
       } finally {

--- a/src/routes/watch.$inviteCode.tsx
+++ b/src/routes/watch.$inviteCode.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { IsolatedGame } from '#/components/show/IsolatedGame';
+import { RealtimeViewerGate } from '#/components/show/RealtimeViewerGate';
 import { getJoinCodeGameQueryOption } from '#/hooks/usejoincodes';
 import { gameboardRouteURLPropsSchema } from '#/lib/schemas/gameboard';
 
@@ -17,5 +18,9 @@ function RouteComponent() {
   const { isiframe } = Route.useSearch();
   const { inviteCode } = Route.useParams();
 
-  return <IsolatedGame gameCode={inviteCode} isIframe={isiframe} />;
+  return (
+    <RealtimeViewerGate code={inviteCode}>
+      <IsolatedGame gameCode={inviteCode} isIframe={isiframe} />
+    </RealtimeViewerGate>
+  );
 }

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -19,7 +19,8 @@ export const getServerAuth = createServerFn({ method: 'GET' }).handler(
     const supabase = createSupabaseServerClient();
     const { data, error } = await supabase.auth.getClaims();
 
-    if (error || !data?.claims.sub) {
+    // Anonymous realtime viewers must never appear as signed-in app users.
+    if (error || !data?.claims.sub || data.claims.is_anonymous === true) {
       return { user: null };
     }
 

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -72,10 +72,18 @@ export const processEvent = createServerFn({ method: 'GET' })
         insertEvent(supabase, event),
       ]);
 
-      await supabase.channel(gameInstanceId).httpSend('GameAction', {
-        type,
-        state,
-      } satisfies SentEvent);
+      const channel = supabase.channel(gameInstanceId, {
+        config: { private: true },
+      });
+      try {
+        const result = await channel.httpSend('GameAction', {
+          type,
+          state,
+        } satisfies SentEvent);
+        if (!result.success) throw new Error(result.error);
+      } finally {
+        await supabase.removeChannel(channel);
+      }
 
       return { gameInstanceId, type, state };
     };

--- a/src/server/joincodes.test.ts
+++ b/src/server/joincodes.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  getClaims: vi.fn(),
+  getServerAuth: vi.fn(),
+  redisDel: vi.fn(),
+  redisGet: vi.fn(),
+  redisSet: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => {
+    const builder = {
+      handler: (handler: unknown) => handler,
+      validator: () => builder,
+    };
+    return builder;
+  },
+}));
+
+vi.mock('#/utils/supabase/backend', () => ({
+  createSupabaseBackendClient: () => ({ from: mocks.from }),
+}));
+
+vi.mock('#/utils/supabase/server', () => ({
+  createSupabaseServerClient: () => ({
+    auth: { getClaims: mocks.getClaims },
+  }),
+}));
+
+vi.mock('#/integrations/redis', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('#/integrations/redis')>();
+  return {
+    ...original,
+    getRedisClient: () => ({
+      del: mocks.redisDel,
+      get: mocks.redisGet,
+      set: mocks.redisSet,
+    }),
+  };
+});
+
+vi.mock('./auth', () => ({
+  getServerAuth: mocks.getServerAuth,
+}));
+
+import { isNotFound } from '@tanstack/react-router';
+import { authorizeRealtimeViewer, deleteJoinCode } from './joincodes';
+
+const GAME_INSTANCE_ID = 'instance-1';
+const OWNER_ID = 'owner-user';
+const VIEWER_ID = 'viewer-user';
+const CODE = 'ABCDE';
+const EXPIRES = '2999-01-01T00:00:00+00:00';
+
+const validRedisEntry = JSON.stringify({
+  code: CODE,
+  gameInstanceId: GAME_INSTANCE_ID,
+  use: 'watch',
+  state: {
+    leftTeam: 'Left',
+    rightTeam: 'Right',
+    gameTitle: 'Game',
+    answers: {},
+  },
+});
+
+type BuilderResult = { data: unknown };
+
+const createBuilder = (getResult: () => BuilderResult) => {
+  const builder = {
+    delete: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    gt: vi.fn(() => builder),
+    maybeSingle: vi.fn(() => builder),
+    select: vi.fn(() => builder),
+    throwOnError: vi.fn(() => Promise.resolve(getResult())),
+    update: vi.fn(() => builder),
+    upsert: vi.fn(() => builder),
+  };
+  return builder;
+};
+
+let instanceResult: BuilderResult;
+const gameInstanceBuilder = createBuilder(() => instanceResult);
+const viewerBuilder = createBuilder(() => ({ data: null }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  instanceResult = { data: null };
+  mocks.from.mockImplementation((table: string) =>
+    table === 'game_realtime_viewers' ? viewerBuilder : gameInstanceBuilder,
+  );
+});
+
+describe('authorizeRealtimeViewer', () => {
+  const setClaims = (sub: string | null) => {
+    mocks.getClaims.mockResolvedValue(
+      sub
+        ? { data: { claims: { sub } }, error: null }
+        : { data: null, error: new Error('no session') },
+    );
+  };
+
+  it('rejects with notFound when there is no session', async () => {
+    setClaims(null);
+
+    await expect(
+      authorizeRealtimeViewer({ data: { code: CODE } }),
+    ).rejects.toSatisfy(isNotFound);
+    expect(mocks.redisGet).not.toHaveBeenCalled();
+  });
+
+  it('rejects with notFound when the code is not in redis', async () => {
+    setClaims(VIEWER_ID);
+    mocks.redisGet.mockResolvedValue(null);
+
+    await expect(
+      authorizeRealtimeViewer({ data: { code: CODE } }),
+    ).rejects.toSatisfy(isNotFound);
+  });
+
+  it('rejects with notFound instead of surfacing malformed redis JSON', async () => {
+    setClaims(VIEWER_ID);
+    mocks.redisGet.mockResolvedValue('{not json');
+
+    await expect(
+      authorizeRealtimeViewer({ data: { code: CODE } }),
+    ).rejects.toSatisfy(isNotFound);
+  });
+
+  it('rejects with notFound instead of surfacing schema-invalid redis data', async () => {
+    setClaims(VIEWER_ID);
+    mocks.redisGet.mockResolvedValue(JSON.stringify({ wrong: 'shape' }));
+
+    await expect(
+      authorizeRealtimeViewer({ data: { code: CODE } }),
+    ).rejects.toSatisfy(isNotFound);
+  });
+
+  it('rejects with notFound when the code is expired or replaced in the database', async () => {
+    setClaims(VIEWER_ID);
+    mocks.redisGet.mockResolvedValue(validRedisEntry);
+    instanceResult = { data: null };
+
+    await expect(
+      authorizeRealtimeViewer({ data: { code: CODE } }),
+    ).rejects.toSatisfy(isNotFound);
+    expect(viewerBuilder.upsert).not.toHaveBeenCalled();
+  });
+
+  it('grants a non-owner viewer access until the join code expires', async () => {
+    setClaims(VIEWER_ID);
+    mocks.redisGet.mockResolvedValue(validRedisEntry);
+    instanceResult = {
+      data: {
+        id: GAME_INSTANCE_ID,
+        userid: OWNER_ID,
+        join_code: CODE,
+        join_code_expires: EXPIRES,
+      },
+    };
+
+    await expect(
+      authorizeRealtimeViewer({ data: { code: CODE } }),
+    ).resolves.toEqual({ gameInstanceId: GAME_INSTANCE_ID });
+
+    expect(viewerBuilder.upsert).toHaveBeenCalledWith({
+      user_id: VIEWER_ID,
+      game_instance_id: GAME_INSTANCE_ID,
+      expires_at: EXPIRES,
+    });
+  });
+
+  it('does not create a grant for the owning host', async () => {
+    setClaims(OWNER_ID);
+    mocks.redisGet.mockResolvedValue(validRedisEntry);
+    instanceResult = {
+      data: {
+        id: GAME_INSTANCE_ID,
+        userid: OWNER_ID,
+        join_code: CODE,
+        join_code_expires: EXPIRES,
+      },
+    };
+
+    await expect(
+      authorizeRealtimeViewer({ data: { code: CODE } }),
+    ).resolves.toEqual({ gameInstanceId: GAME_INSTANCE_ID });
+    expect(viewerBuilder.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteJoinCode', () => {
+  it('rejects with notFound when unauthenticated', async () => {
+    mocks.getServerAuth.mockResolvedValue({ user: null });
+
+    await expect(
+      deleteJoinCode({ data: { code: CODE } }),
+    ).rejects.toSatisfy(isNotFound);
+    expect(mocks.redisDel).not.toHaveBeenCalled();
+  });
+
+  it('rejects with notFound when the caller does not own the game', async () => {
+    mocks.getServerAuth.mockResolvedValue({ user: { id: VIEWER_ID } });
+    instanceResult = { data: { id: GAME_INSTANCE_ID, userid: OWNER_ID } };
+
+    await expect(
+      deleteJoinCode({ data: { code: CODE } }),
+    ).rejects.toSatisfy(isNotFound);
+    expect(mocks.redisDel).not.toHaveBeenCalled();
+    expect(viewerBuilder.delete).not.toHaveBeenCalled();
+  });
+
+  it('removes viewer grants, join code columns, and the redis key for the owner', async () => {
+    mocks.getServerAuth.mockResolvedValue({ user: { id: OWNER_ID } });
+    instanceResult = { data: { id: GAME_INSTANCE_ID, userid: OWNER_ID } };
+    mocks.redisDel.mockResolvedValue(1);
+
+    await expect(deleteJoinCode({ data: { code: CODE } })).resolves.toEqual({
+      success: true,
+    });
+
+    expect(viewerBuilder.delete).toHaveBeenCalled();
+    expect(viewerBuilder.eq).toHaveBeenCalledWith(
+      'game_instance_id',
+      GAME_INSTANCE_ID,
+    );
+    expect(gameInstanceBuilder.update).toHaveBeenCalledWith({
+      join_code: null,
+      join_code_expires: null,
+    });
+    expect(mocks.redisDel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/joincodes.ts
+++ b/src/server/joincodes.ts
@@ -10,6 +10,7 @@ import {
   redisCodeStorageUpdateSchema,
 } from '#/lib/schemas/joincode';
 import { createSupabaseBackendClient } from '#/utils/supabase/backend';
+import { createSupabaseServerClient } from '#/utils/supabase/server';
 import {
   getGameInstance,
   getGameInstanceUser,
@@ -85,6 +86,12 @@ export const createJoinCode = createServerFn({ method: 'GET' })
       }
 
       if (success) {
+        // Replacing a code invalidates any viewer grants issued under it.
+        await supabase
+          .from('game_realtime_viewers')
+          .delete()
+          .eq('game_instance_id', gameInstanceId)
+          .throwOnError();
         await supabase
           .from('game_instance')
           .update({
@@ -158,8 +165,75 @@ export const deleteJoinCode = createServerFn({ method: 'POST' })
   .validator(getJoinCodeGameRPCSchema)
   .handler(async ({ data }) => {
     const auth = await getServerAuth();
-    if (!auth.user) return;
+    if (!auth.user) throw notFound();
     const code = normalizeJoinCode(data.code);
+
+    const { data: instance } = await supabase
+      .from('game_instance')
+      .select('id, userid')
+      .eq('join_code', code)
+      .maybeSingle()
+      .throwOnError();
+
+    if (!instance || instance.userid !== auth.user.id) throw notFound();
+
+    await supabase
+      .from('game_realtime_viewers')
+      .delete()
+      .eq('game_instance_id', instance.id)
+      .throwOnError();
+    await supabase
+      .from('game_instance')
+      .update({ join_code: null, join_code_expires: null })
+      .eq('id', instance.id)
+      .throwOnError();
+
     const success = !!(await redis.del([getJoinCodeRedisKey(code)]));
     return { success };
+  });
+
+export const authorizeRealtimeViewer = createServerFn({ method: 'POST' })
+  .validator(getJoinCodeGameRPCSchema)
+  .handler(async ({ data: { code: inputCode } }) => {
+    const authClient = createSupabaseServerClient();
+    const { data: claims, error } = await authClient.auth.getClaims();
+
+    if (error || !claims?.claims.sub) throw notFound();
+
+    const code = normalizeJoinCode(inputCode);
+    const redisReturn = await redis.get(getJoinCodeRedisKey(code));
+    if (!redisReturn) throw notFound();
+
+    let parsedRedis: unknown;
+    try {
+      parsedRedis = JSON.parse(redisReturn);
+    } catch {
+      throw notFound();
+    }
+    const cached = redisCodeStorageSchema.safeParse(parsedRedis);
+    if (!cached.success) throw notFound();
+
+    const { data: instance } = await supabase
+      .from('game_instance')
+      .select('id, userid, join_code, join_code_expires')
+      .eq('id', cached.data.gameInstanceId)
+      .eq('join_code', code)
+      .gt('join_code_expires', new Date().toISOString())
+      .maybeSingle()
+      .throwOnError();
+
+    if (!instance?.join_code_expires) throw notFound();
+
+    if (instance.userid !== claims.claims.sub) {
+      await supabase
+        .from('game_realtime_viewers')
+        .upsert({
+          user_id: claims.claims.sub,
+          game_instance_id: instance.id,
+          expires_at: instance.join_code_expires,
+        })
+        .throwOnError();
+    }
+
+    return { gameInstanceId: instance.id };
   });

--- a/src/supabaseauth.tsx
+++ b/src/supabaseauth.tsx
@@ -11,9 +11,11 @@ export interface AuthContext {
   login: ({
     email,
     password,
+    captchaToken,
   }: {
     email: string;
     password: string;
+    captchaToken?: string;
   }) => Promise<void>;
   logout: () => Promise<void>;
   isLoggingIn: boolean;
@@ -44,20 +46,32 @@ export const SupabaseAuthProvider = ({
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null);
+      // Anonymous realtime viewers never count as signed-in app users.
+      const nextUser =
+        session?.user && !session.user.is_anonymous ? session.user : null;
+      setUser(nextUser);
     });
 
     return () => subscription.unsubscribe();
   }, [supabase]);
 
   const login = React.useCallback(
-    async ({ email, password }: { email: string; password: string }) => {
+    async ({
+      email,
+      password,
+      captchaToken,
+    }: {
+      email: string;
+      password: string;
+      captchaToken?: string;
+    }) => {
       setIsLoggingIn(true);
       setError(null);
       try {
         const { error: authError } = await supabase.auth.signInWithPassword({
           email,
           password,
+          options: captchaToken ? { captchaToken } : undefined,
         });
 
         if (authError) {

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -244,6 +244,42 @@ export type Database = {
           },
         ]
       }
+      game_realtime_viewers: {
+        Row: {
+          created_at: string
+          expires_at: string
+          game_instance_id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          expires_at: string
+          game_instance_id: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          expires_at?: string
+          game_instance_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "game_realtime_viewers_game_instance_id_fkey"
+            columns: ["game_instance_id"]
+            isOneToOne: false
+            referencedRelation: "active_games"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "game_realtime_viewers_game_instance_id_fkey"
+            columns: ["game_instance_id"]
+            isOneToOne: false
+            referencedRelation: "game_instance"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       games: {
         Row: {
           created_at: string

--- a/supabase/migrations/20260706050856_remote_schema.sql
+++ b/supabase/migrations/20260706050856_remote_schema.sql
@@ -1,0 +1,27 @@
+revoke delete on table "public"."game_realtime_viewers" from "anon";
+
+revoke insert on table "public"."game_realtime_viewers" from "anon";
+
+revoke references on table "public"."game_realtime_viewers" from "anon";
+
+revoke select on table "public"."game_realtime_viewers" from "anon";
+
+revoke trigger on table "public"."game_realtime_viewers" from "anon";
+
+revoke truncate on table "public"."game_realtime_viewers" from "anon";
+
+revoke update on table "public"."game_realtime_viewers" from "anon";
+
+revoke delete on table "public"."game_realtime_viewers" from "authenticated";
+
+revoke insert on table "public"."game_realtime_viewers" from "authenticated";
+
+revoke references on table "public"."game_realtime_viewers" from "authenticated";
+
+revoke trigger on table "public"."game_realtime_viewers" from "authenticated";
+
+revoke truncate on table "public"."game_realtime_viewers" from "authenticated";
+
+revoke update on table "public"."game_realtime_viewers" from "authenticated";
+
+

--- a/supabase/migrations/20260706050856_remote_schema.sql
+++ b/supabase/migrations/20260706050856_remote_schema.sql
@@ -1,27 +1,13 @@
 revoke delete on table "public"."game_realtime_viewers" from "anon";
-
 revoke insert on table "public"."game_realtime_viewers" from "anon";
-
 revoke references on table "public"."game_realtime_viewers" from "anon";
-
 revoke select on table "public"."game_realtime_viewers" from "anon";
-
 revoke trigger on table "public"."game_realtime_viewers" from "anon";
-
 revoke truncate on table "public"."game_realtime_viewers" from "anon";
-
 revoke update on table "public"."game_realtime_viewers" from "anon";
-
 revoke delete on table "public"."game_realtime_viewers" from "authenticated";
-
 revoke insert on table "public"."game_realtime_viewers" from "authenticated";
-
 revoke references on table "public"."game_realtime_viewers" from "authenticated";
-
 revoke trigger on table "public"."game_realtime_viewers" from "authenticated";
-
 revoke truncate on table "public"."game_realtime_viewers" from "authenticated";
-
 revoke update on table "public"."game_realtime_viewers" from "authenticated";
-
-

--- a/supabase/migrations/20260709015533_remote_schema.sql
+++ b/supabase/migrations/20260709015533_remote_schema.sql
@@ -1,0 +1,1 @@
+alter table "public"."game_instance" alter column "question_text" set default ''::text;


### PR DESCRIPTION
## Summary

Adds anonymous/guest viewer access to live games over Supabase realtime, gated by server-validated join codes, plus the RLS/broadcast authorization to scope it safely. Includes a security review pass on the auth redirect helper.

## What's included
- **Realtime viewer access:** `RealtimeViewerGate`, join-code authorization flow (`src/server/joincodes.ts`, `watch.$inviteCode.tsx`), and private broadcast subscription (`useGameActionSubscription.tsx` with `config: { private: true }`).
- **Server-side join-code validation:** `authorizeRealtimeViewer` checks Redis + the `game_instance` row (matching, unexpired `join_code`) before granting; grants scoped to the caller and inherit the code's expiry. Covered by `src/server/joincodes.test.ts`.
- **Auth flow:** CAPTCHA (`AuthCaptcha.tsx`), sign-up/forgot-password wiring, anonymous session handling in `supabaseauth.tsx`.
- **DB migration:** `20260706050856_remote_schema.sql`.

## Security review
Ran a focused security review of the realtime changes. Realtime model verified sound: minimal `supabase_realtime` publication (only `game_events`), fail-closed RLS for anonymous sessions, broadcast authorization scoped per-grant, server-side join-code validation, and service-role key kept server-only.

One concrete fix applied: `getSafeRedirectPath` now rejects backslashes, closing an open-redirect edge case (`/\evil.com` → `https://evil.com`) on the auth callback's success `href` sink. Regression tests added in `src/lib/auth.test.ts`.

## Test plan
- `pnpm vitest run src/lib/auth.test.ts` — passing
- `pnpm vitest run src/server/joincodes.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)