### PR TITLE
Add host and viewer volume controls

### DIFF
--- a/src/components/gamecontrol/VolumeControls.tsx
+++ b/src/components/gamecontrol/VolumeControls.tsx
@@ -1,0 +1,136 @@
+import { Volume2, VolumeX } from 'lucide-react';
+import React from 'react';
+import type { VolumeEvent } from '#/lib/schemas/events';
+import { Button } from '@/components/ui/button';
+import { Slider } from '@/components/ui/slider';
+import { useLocalStorage } from '@/hooks/uselocalstorage';
+import { useSupabase } from '@/hooks/useSupabase';
+
+type HostVolumeSettings = {
+  local: VolumeEvent;
+  remote: VolumeEvent;
+};
+
+const HOST_VOLUME_KEY = 'feud-host-volume';
+
+const DEFAULT_HOST_VOLUME: HostVolumeSettings = {
+  local: { volume: 1, muted: false },
+  remote: { volume: 1, muted: false },
+};
+
+export const useHostVolume = () =>
+  useLocalStorage(HOST_VOLUME_KEY, DEFAULT_HOST_VOLUME);
+
+const useSendRemoteVolume = (gameInstanceId: string) => {
+  const supabase = useSupabase();
+
+  return React.useCallback(
+    async (setting: VolumeEvent) => {
+      const channel = supabase.channel(gameInstanceId, {
+        config: { private: true },
+      });
+      try {
+        await channel.httpSend('volume', setting);
+      } finally {
+        await supabase.removeChannel(channel);
+      }
+    },
+    [gameInstanceId, supabase],
+  );
+};
+
+// Broadcasts are ephemeral, so a presentation only hears settings sent while
+// it is subscribed. Re-sending the stored remote setting when the host page
+// mounts covers presentations opened before the host page.
+export const useBroadcastRemoteVolumeOnMount = (gameInstanceId: string) => {
+  const sendRemoteVolume = useSendRemoteVolume(gameInstanceId);
+  const [settings] = useHostVolume();
+  const remoteRef = React.useRef(settings.remote);
+
+  React.useEffect(() => {
+    remoteRef.current = settings.remote;
+  }, [settings.remote]);
+
+  React.useEffect(() => {
+    void sendRemoteVolume(remoteRef.current);
+  }, [sendRemoteVolume]);
+};
+
+const VolumeRow = ({
+  label,
+  setting,
+  onChange,
+  onCommit,
+}: {
+  label: string;
+  setting: VolumeEvent;
+  onChange: (setting: VolumeEvent) => void;
+  onCommit?: (setting: VolumeEvent) => void;
+}) => {
+  const handleMuteToggle = () => {
+    const next = { ...setting, muted: !setting.muted };
+    onChange(next);
+    onCommit?.(next);
+  };
+
+  const toSetting = (values: number[]): VolumeEvent | null => {
+    const value = values[0];
+    return value === undefined ? null : { ...setting, volume: value / 100 };
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-24 shrink-0 text-sm">{label}</span>
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label={setting.muted ? `Unmute ${label}` : `Mute ${label}`}
+        onClick={handleMuteToggle}
+      >
+        {setting.muted ? <VolumeX /> : <Volume2 />}
+      </Button>
+      <Slider
+        value={[Math.round(setting.volume * 100)]}
+        min={0}
+        max={100}
+        step={1}
+        aria-label={`${label} volume`}
+        onValueChange={(values) => {
+          const next = toSetting(values);
+          if (next) onChange(next);
+        }}
+        onValueCommit={(values) => {
+          const next = toSetting(values);
+          if (next) onCommit?.(next);
+        }}
+      />
+    </div>
+  );
+};
+
+export const VolumeControls = ({
+  gameInstanceId,
+}: {
+  gameInstanceId: string;
+}) => {
+  const [settings, setSettings] = useHostVolume();
+  const sendRemoteVolume = useSendRemoteVolume(gameInstanceId);
+
+  return (
+    <div className="flex flex-col gap-2 mx-4 pb-2">
+      <VolumeRow
+        label="This device"
+        setting={settings.local}
+        onChange={(local) => setSettings((current) => ({ ...current, local }))}
+      />
+      <VolumeRow
+        label="Presentation"
+        setting={settings.remote}
+        onChange={(remote) =>
+          setSettings((current) => ({ ...current, remote }))
+        }
+        onCommit={(remote) => void sendRemoteVolume(remote)}
+      />
+    </div>
+  );
+};

--- a/src/components/providers/GameControl.tsx
+++ b/src/components/providers/GameControl.tsx
@@ -7,6 +7,7 @@ import {
   toGameBoardState,
 } from '#/lib/gameboard-state';
 import type { GameBoardState } from '#/lib/schemas/gameboard';
+import { useHostVolume } from '@/components/gamecontrol/VolumeControls';
 import { useGameActionSubscription } from '@/hooks/useGameActionSubscription';
 import {
   getGetGameInstanceQueryKey,
@@ -37,6 +38,7 @@ export function GameControlProvider({
 }: GameControlProviderProps) {
   const queryClient = useQueryClient();
   const { data: gameInstance } = useGetGameInstance(instanceId);
+  const [{ local: localVolume }] = useHostVolume();
 
   const updateGameInstanceState = React.useCallback(
     (nextState: GameBoardState) => {
@@ -54,7 +56,8 @@ export function GameControlProvider({
   useGameActionSubscription({
     channelId: instanceId,
     onState: updateGameInstanceState,
-    soundsEnabled: false,
+    soundsEnabled: true,
+    volume: localVolume.muted ? 0 : localVolume.volume,
   });
 
   const state = React.useMemo(

--- a/src/components/show/IsolatedGame.tsx
+++ b/src/components/show/IsolatedGame.tsx
@@ -5,6 +5,7 @@ import Confetti from 'react-confetti';
 import { FullScreen, useFullScreenHandle } from 'react-full-screen';
 import { useIsolatedViewer } from '#/hooks/useIsolatedViewer';
 import { useWindowSize } from '#/hooks/useWindowSize';
+import type { VolumeEvent } from '#/lib/schemas/events';
 import type { ConfettiMode } from '#/lib/schemas/game';
 import GameBg from '@/components/show/GameBg';
 import { Button } from '@/components/ui/button';
@@ -12,6 +13,7 @@ import { cn } from '@/utils/utils';
 import { Winner } from '../Winner';
 import Gameboard from './Gameboard';
 import Strike from './Strike';
+import { useViewerVolumePrefs, VolumeControl } from './VolumeControl';
 
 const TeamName = ({ value }: { value: string }) => {
   const long = value.length >= 11;
@@ -76,6 +78,12 @@ export const IsolatedGame = ({
 }) => {
   const fullscreen = useFullScreenHandle();
   const navigate = useNavigate();
+  const [hostVolume, setHostVolume] = React.useState<VolumeEvent>({
+    volume: 1,
+    muted: false,
+  });
+  const [viewerPrefs, setViewerPrefs] = useViewerVolumePrefs();
+  const activeVolume = viewerPrefs.override ? viewerPrefs : hostVolume;
   const {
     strikes,
     showStrikes,
@@ -88,7 +96,13 @@ export const IsolatedGame = ({
     leftScore,
     confettiMode,
     gameover,
-  } = useIsolatedViewer(gameCode);
+  } = useIsolatedViewer(gameCode, {
+    // The embedded iframe on the host page stays silent; the host page
+    // itself plays sounds so audio works even when the iframe is hidden.
+    soundsEnabled: !isIframe,
+    volume: activeVolume.muted ? 0 : activeVolume.volume,
+    onVolume: setHostVolume,
+  });
 
   const handleFullscreenClick = () => {
     if (fullscreen.active) {
@@ -142,10 +156,20 @@ export const IsolatedGame = ({
         ))}
       <div
         className={cn(
-          'absolute top-2 right-2',
+          'absolute top-2 right-2 flex',
           fullscreen.active ? 'text-muted' : '',
         )}
       >
+        <VolumeControl
+          hostSetting={hostVolume}
+          prefs={viewerPrefs}
+          onPrefsChange={setViewerPrefs}
+          className={cn(
+            isIframe
+              ? 'opacity-0 pointer-events-none'
+              : 'opacity-100 pointer-events-auto',
+          )}
+        />
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/show/VolumeControl.tsx
+++ b/src/components/show/VolumeControl.tsx
@@ -1,0 +1,97 @@
+import { Volume2, VolumeX } from 'lucide-react';
+import type React from 'react';
+import type { VolumeEvent } from '#/lib/schemas/events';
+import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Slider } from '@/components/ui/slider';
+import { Switch } from '@/components/ui/switch';
+import { useLocalStorage } from '@/hooks/uselocalstorage';
+
+export type ViewerVolumePrefs = VolumeEvent & {
+  override: boolean;
+};
+
+const VIEWER_VOLUME_KEY = 'feud-viewer-volume';
+
+const DEFAULT_VIEWER_PREFS: ViewerVolumePrefs = {
+  override: false,
+  volume: 1,
+  muted: false,
+};
+
+export const useViewerVolumePrefs = () =>
+  useLocalStorage(VIEWER_VOLUME_KEY, DEFAULT_VIEWER_PREFS);
+
+export const VolumeControl = ({
+  hostSetting,
+  prefs,
+  onPrefsChange,
+  className,
+}: {
+  hostSetting: VolumeEvent;
+  prefs: ViewerVolumePrefs;
+  onPrefsChange: React.Dispatch<React.SetStateAction<ViewerVolumePrefs>>;
+  className?: string;
+}) => {
+  const active = prefs.override ? prefs : hostSetting;
+  const silent = active.muted || active.volume === 0;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Volume settings"
+          className={className}
+        >
+          {silent ? <VolumeX /> : <Volume2 />}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="flex w-64 flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <span className="text-sm">Follow host</span>
+          <Switch
+            checked={!prefs.override}
+            onCheckedChange={(checked) =>
+              onPrefsChange((current) => ({ ...current, override: !checked }))
+            }
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            disabled={!prefs.override}
+            aria-label={active.muted ? 'Unmute' : 'Mute'}
+            onClick={() =>
+              onPrefsChange((current) => ({
+                ...current,
+                muted: !current.muted,
+              }))
+            }
+          >
+            {active.muted ? <VolumeX /> : <Volume2 />}
+          </Button>
+          <Slider
+            value={[Math.round(active.volume * 100)]}
+            min={0}
+            max={100}
+            step={1}
+            disabled={!prefs.override}
+            aria-label="Presentation volume"
+            onValueChange={(values) => {
+              const value = values[0];
+              if (value === undefined) return;
+              onPrefsChange((current) => ({ ...current, volume: value / 100 }));
+            }}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,58 @@
+import { Slider as SliderPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { cn } from '#/lib/utils.ts';
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max],
+  );
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        'relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:min-h-40 data-vertical:w-auto data-vertical:flex-col',
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className="relative grow overflow-hidden rounded-none bg-muted data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1"
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className="absolute bg-primary select-none data-horizontal:h-full data-vertical:w-full"
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          // biome-ignore lint/suspicious/noArrayIndexKey: thumbs are purely positional
+          key={index}
+          className="relative block size-3 shrink-0 rounded-none border border-ring bg-white ring-ring/50 transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-1 focus-visible:ring-1 focus-visible:outline-hidden active:ring-1 disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };

--- a/src/hooks/useGameActionSubscription.tsx
+++ b/src/hooks/useGameActionSubscription.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import type { ActionType } from '#/lib/schemas/base';
-import { sentEvent, soundEvent } from '#/lib/schemas/events';
+import {
+  sentEvent,
+  soundEvent,
+  type VolumeEvent,
+  volumeEvent,
+} from '#/lib/schemas/events';
 import type { GameBoardState } from '#/lib/schemas/gameboard';
 import { useGameSounds } from './useGameSounds';
 import { useSupabase } from './useSupabase';
@@ -9,30 +14,37 @@ type UseGameActionSubscriptionProps = {
   channelId?: string | null;
   onAction?: (type: ActionType, state: GameBoardState) => void;
   onState?: (state: GameBoardState) => void;
+  onVolume?: (settings: VolumeEvent) => void;
   soundsEnabled?: boolean;
+  volume?: number;
 };
 
 export const useGameActionSubscription = ({
   channelId,
   onAction,
   onState,
+  onVolume,
   soundsEnabled = true,
+  volume = 1,
 }: UseGameActionSubscriptionProps) => {
   const supabase = useSupabase();
   const { playSound, playActionSound } = useGameSounds({
     enabled: soundsEnabled,
+    volume,
   });
   const onActionRef = React.useRef(onAction);
   const onStateRef = React.useRef(onState);
+  const onVolumeRef = React.useRef(onVolume);
   const playSoundRef = React.useRef(playSound);
   const playActionSoundRef = React.useRef(playActionSound);
 
   React.useEffect(() => {
     onActionRef.current = onAction;
     onStateRef.current = onState;
+    onVolumeRef.current = onVolume;
     playSoundRef.current = playSound;
     playActionSoundRef.current = playActionSound;
-  }, [onAction, onState, playActionSound, playSound]);
+  }, [onAction, onState, onVolume, playActionSound, playSound]);
 
   React.useEffect(() => {
     if (!channelId) return;
@@ -50,6 +62,10 @@ export const useGameActionSubscription = ({
       .on('broadcast', { event: 'sound' }, (event) => {
         const result = soundEvent.safeParse(event.payload);
         if (result.success) playSoundRef.current(result.data.sound);
+      })
+      .on('broadcast', { event: 'volume' }, (event) => {
+        const result = volumeEvent.safeParse(event.payload);
+        if (result.success) onVolumeRef.current?.(result.data);
       })
       .subscribe();
 

--- a/src/hooks/useGameSounds.tsx
+++ b/src/hooks/useGameSounds.tsx
@@ -5,6 +5,7 @@ import type { GameSound } from '#/lib/schemas/events';
 
 type UseGameSoundsProps = {
   enabled?: boolean;
+  volume?: number;
 };
 
 type UseGameSoundsResult = {
@@ -22,30 +23,31 @@ const ACTION_SOUNDS: Partial<Record<ActionType, GameSound>> = {
 
 export const useGameSounds = ({
   enabled = true,
+  volume = 1,
 }: UseGameSoundsProps = {}): UseGameSoundsResult => {
   const [ding] = useSound(
     'https://utfs.io/f/H6iSz68ZupCoYLk2Vwhdq2xsSpPTCoOnh5XK83a70LRkiGEt',
-    { format: ['mp3'], soundEnabled: enabled },
+    { format: ['mp3'], soundEnabled: enabled, volume },
   );
   const [strike] = useSound(
     'https://utfs.io/f/H6iSz68ZupCoMbf0C2NhZrC7uiAx6FkNYzDa84bnsqyKpdQB',
-    { format: ['mp3'], soundEnabled: enabled },
+    { format: ['mp3'], soundEnabled: enabled, volume },
   );
   const [faceOffMusic] = useSound(
     'https://utfs.io/f/H6iSz68ZupCo4eKhb35E9ulnKd6JjxQ1WkrV4qp5YX3oHg0w',
-    { format: ['mp3'], soundEnabled: enabled },
+    { format: ['mp3'], soundEnabled: enabled, volume },
   );
   const [faceOffBuzzer] = useSound(
     'https://utfs.io/f/H6iSz68ZupCoAiLTGxMQAScDCsTuMnEmH91yakxB76plzKiq',
-    { format: ['mp3'], soundEnabled: enabled },
+    { format: ['mp3'], soundEnabled: enabled, volume },
   );
   const [themeMusic] = useSound(
     'https://utfs.io/f/H6iSz68ZupCoNGkGGFloauFQZAbTpW4OP5hCSDJM6Igcj9r2',
-    { format: ['mp3'], soundEnabled: enabled },
+    { format: ['mp3'], soundEnabled: enabled, volume },
   );
   const [clap] = useSound(
     'https://utfs.io/f/H6iSz68ZupCoI8HGXcx1w0amDS2udhsfqj97lFyLkcIAQCez',
-    { format: ['mp3'], soundEnabled: enabled },
+    { format: ['mp3'], soundEnabled: enabled, volume },
   );
 
   const enabledRef = React.useRef(enabled);

--- a/src/hooks/useIsolatedViewer.tsx
+++ b/src/hooks/useIsolatedViewer.tsx
@@ -1,12 +1,22 @@
 import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
+import type { VolumeEvent } from '#/lib/schemas/events';
 import type { GameBoardState } from '#/lib/schemas/gameboard';
 import type { RedisCodeStorageType } from '#/lib/schemas/joincode';
 import { useGameActionSubscription } from './useGameActionSubscription';
 import { getJoinCodeGameQueryKey, useGetJoinCodeGame } from './usejoincodes';
 import { useStrikeOverlay } from './useStrikeOverlay';
 
-export const useIsolatedViewer = (joinCode: string) => {
+type UseIsolatedViewerOptions = {
+  soundsEnabled?: boolean;
+  volume?: number;
+  onVolume?: (settings: VolumeEvent) => void;
+};
+
+export const useIsolatedViewer = (
+  joinCode: string,
+  { soundsEnabled = true, volume = 1, onVolume }: UseIsolatedViewerOptions = {},
+) => {
   const { data } = useGetJoinCodeGame(joinCode);
   const queryClient = useQueryClient();
   const {
@@ -49,7 +59,9 @@ export const useIsolatedViewer = (joinCode: string) => {
     channelId: data?.gameInstanceId,
     onAction: handleAction,
     onState: updateQuery,
-    soundsEnabled: true,
+    onVolume,
+    soundsEnabled,
+    volume,
   });
 
   const state = data?.state;

--- a/src/hooks/uselocalstorage.tsx
+++ b/src/hooks/uselocalstorage.tsx
@@ -13,22 +13,26 @@ export function useLocalStorage<T>(
   initialValue: T | (() => T),
   options: UseLocalStorageOptions<T> = {},
 ): [T, React.Dispatch<React.SetStateAction<T>>, () => void] {
-  const { initializeWithValue = true } = options;
+  const {
+    initializeWithValue = true,
+    serializer: customSerializer,
+    deserializer: customDeserializer,
+  } = options;
 
   const serializer = React.useCallback(
     (value: T): string => {
-      if (options.serializer) {
-        return options.serializer(value);
+      if (customSerializer) {
+        return customSerializer(value);
       }
       return JSON.stringify(value);
     },
-    [options],
+    [customSerializer],
   );
 
   const deserializer = React.useCallback(
     (value: string): T => {
-      if (options.deserializer) {
-        return options.deserializer(value);
+      if (customDeserializer) {
+        return customDeserializer(value);
       }
       if (value === 'undefined') {
         return undefined as unknown as T;
@@ -41,7 +45,7 @@ export function useLocalStorage<T>(
         return defaultValue;
       }
     },
-    [options, initialValue],
+    [customDeserializer, initialValue],
   );
 
   const readValue = React.useCallback((): T => {

--- a/src/lib/schemas/events.ts
+++ b/src/lib/schemas/events.ts
@@ -158,3 +158,9 @@ export type GameSound = z.infer<typeof gameSoundEnum>;
 export const soundEvent = z.object({
   sound: gameSoundEnum,
 });
+
+export const volumeEvent = z.object({
+  volume: z.number().min(0).max(1),
+  muted: z.boolean(),
+});
+export type VolumeEvent = z.infer<typeof volumeEvent>;

--- a/src/routes/_auth.c.$gameInstanceId.tsx
+++ b/src/routes/_auth.c.$gameInstanceId.tsx
@@ -11,6 +11,10 @@ import { useElementSize } from '#/hooks/useElementSize';
 import { useMediaQuery } from '#/hooks/useMediaQuery';
 import type { GameSound } from '#/lib/schemas/events';
 import Strikes from '@/components/gamecontrol/Strikes';
+import {
+  useBroadcastRemoteVolumeOnMount,
+  VolumeControls,
+} from '@/components/gamecontrol/VolumeControls';
 import { Button } from '@/components/ui/button';
 import {
   Drawer,
@@ -125,6 +129,10 @@ function ControlComponent() {
 
   const { state } = useGameControlContext();
 
+  // The drawer content only mounts when opened, so send the stored
+  // presentation volume from here on page load.
+  useBroadcastRemoteVolumeOnMount(gameInstanceId);
+
   // if (isLoading && isFeudEventsLoading) return <div>Loading...</div>;
   // if (isError) return <div>{error.message}</div>;
   // if (!data) return <div>no data yet</div>;
@@ -220,6 +228,7 @@ function ControlComponent() {
                 Play sound effects using buttons from here
               </DrawerDescription>
             </DrawerHeader>
+            <VolumeControls gameInstanceId={gameInstanceId} />
             <div className="flex flex-col mx-4 gap-2">
               <Button onClick={() => handleSendSound('ding')}>Ding</Button>
               <Button onClick={() => handleSendSound('strike')}>Strike</Button>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,8 +1,6 @@
-@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Manrope:wght@400;500;600;700;800&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/inter/wght.css";
 @plugin "@tailwindcss/typography";
 @custom-variant dark (&:is(.dark *));
 
@@ -12,18 +10,18 @@
   font-display: swap;
 }
 
+/* inter-latin-wght-normal */
 @font-face {
   font-family: "Inter Variable";
   font-style: normal;
   font-display: swap;
-  font-weight: 500;
-  src:
-    url("@fontsource/inter/files/inter-latin-500-normal.woff2") format("woff2"),
-    url("@fontsource/inter/files/inter-latin-500-normal.woff") format("woff");
-
+  font-weight: 100 900;
+  src: url("@fontsource-variable/inter/files/inter-latin-wght-medium.woff2")
+    format("woff2-variations");
   unicode-range:
     U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
+
 :root {
   --yellow-lt: #fcd836ff;
   --feudblue: #090087;


### PR DESCRIPTION
## Summary
- Added host-side local and presentation volume controls with persisted settings and a broadcast-on-mount sync for the presentation channel.
- Added viewer volume preferences in the isolated game view, including follow-host/override behavior and persistent local storage.
- Wired game sound playback to respect volume settings and enabled sound playback in the host control provider.
- Added a reusable slider component and volume event schema to support the new controls.

## Testing
- Not run (no automated tests executed).
- Reviewed the diff for volume propagation through `useGameActionSubscription`, `useGameSounds`, and `useIsolatedViewer`.
- Verified the new UI paths are wired into the host drawer and isolated game header.